### PR TITLE
fix: Specifying the assemble version as the latest was throwing an error

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "grunt-cucumber": "~0.2.1",
     "grunt-plato": "~0.2.0",
     "grunt-contrib-copy": "~0.4.1",
-    "assemble": "~0.4.13",
+    "assemble": "0.4.13",
     "grunt-contrib-connect": "~0.5.0",
     "connect-livereload": "~0.3.0",
     "grunt-grunticon": "~1.0.0",


### PR DESCRIPTION
The `~` was causing assemble to load 0.4.40, which was throwing an error.

pinging @neilrenicker 
